### PR TITLE
Initial creation of Wiki class to hold data from OSF API.

### DIFF
--- a/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
@@ -19,10 +19,7 @@ import static org.dataconservancy.cos.osf.client.support.JodaSupport.DATE_TIME_F
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import org.dataconservancy.cos.osf.client.support.DateTimeTransform;
-import org.dataconservancy.cos.osf.client.support.DownloadLinkTransform;
 import org.dataconservancy.cos.osf.client.support.JodaSupport;
 import org.dataconservancy.cos.osf.client.support.ProviderIdTransform;
 import org.dataconservancy.cos.rdf.annotations.IndividualUri;
@@ -110,15 +107,15 @@ public class Wiki {
         this.name = name;
     }
 
-    public String getMaterializedPath() {
+    public String getMaterialized_path() {
         return materialized_path;
     }
 
-    public void setMaterializedPath(String materialized_path) {
+    public void setMaterialized_path(String materialized_path) {
         this.materialized_path = materialized_path;
     }
 
-    public String getDateModified() {
+    public String getDate_modified() {
         if (this.date_modified!=null) {
             return this.date_modified.toString(DATE_TIME_FORMATTER_ALT);
         } else {
@@ -126,7 +123,7 @@ public class Wiki {
         }
     }
 
-    public void setDateModified(String date_modified) {
+    public void setDate_modified(String date_modified) {
         if (date_modified!=null){
             this.date_modified = JodaSupport.parseDateTime(date_modified);
         } else {
@@ -142,11 +139,11 @@ public class Wiki {
         this.path = path;
     }
 
-    public String getContentType() {
+    public String getContent_type() {
         return content_type;
     }
 
-    public void setContentType(String content_type) {
+    public void setContent_type(String content_type) {
         this.content_type = content_type;
     }
 
@@ -167,11 +164,11 @@ public class Wiki {
         this.links = links;
     }
 
-    public Map<String, ?> getVersion() {
+    public Map<String, ?> getExtra() {
         return extra;
     }
 
-    public void setVersion(Map<String, ?> extra) { this.extra = extra; }
+    public void setExtra(Map<String, ?> extra) { this.extra = extra; }
 
     public String getId() {
         return id;

--- a/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
@@ -42,12 +42,17 @@ import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Type("wikis")
 public class Wiki {
 
+    @Id
     private String id;
 
+    @Relationship(value = "comments", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.OBJECT)
     private List<Comment> comments;
 
+    @Links
     private Map<String, ?> links;
 
     private String name;
@@ -58,8 +63,10 @@ public class Wiki {
 
     private DateTime date_modified;
 
+    @Relationship(value = "node", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.REF)
     private String node;
 
+    @Relationship(value = "user", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.REF)
     private String user;
 
     private String path;
@@ -103,15 +110,15 @@ public class Wiki {
         this.name = name;
     }
 
-    public String getMaterialized_path() {
+    public String getMaterializedPath() {
         return materialized_path;
     }
 
-    public void setMaterialized_path(String materialized_path) {
+    public void setMaterializedPath(String materialized_path) {
         this.materialized_path = materialized_path;
     }
 
-    public String getDate_modified() {
+    public String getDateModified() {
         if (this.date_modified!=null) {
             return this.date_modified.toString(DATE_TIME_FORMATTER_ALT);
         } else {
@@ -119,7 +126,7 @@ public class Wiki {
         }
     }
 
-    public void setDate_modified(String date_modified) {
+    public void setDateModified(String date_modified) {
         if (date_modified!=null){
             this.date_modified = JodaSupport.parseDateTime(date_modified);
         } else {
@@ -155,6 +162,7 @@ public class Wiki {
         return links;
     }
 
+    @JsonProperty("links")
     public void setLinks(Map<String, ?> links) {
         this.links = links;
     }

--- a/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
@@ -17,15 +17,12 @@ package org.dataconservancy.cos.osf.client.model;
 
 import static org.dataconservancy.cos.osf.client.support.JodaSupport.DATE_TIME_FORMATTER_ALT;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonSetter;
 import org.dataconservancy.cos.osf.client.support.DateTimeTransform;
 import org.dataconservancy.cos.osf.client.support.DownloadLinkTransform;
-import org.dataconservancy.cos.osf.client.support.FileIdTransform;
 import org.dataconservancy.cos.osf.client.support.JodaSupport;
 import org.dataconservancy.cos.osf.client.support.ProviderIdTransform;
 import org.dataconservancy.cos.rdf.annotations.IndividualUri;
@@ -45,68 +42,33 @@ import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 
 
-/**
- * Wiki model for OSF
- * Created by Ben Trumbore on 9/16/2016.
- */
-//@Type("wiki")
-//@JsonIgnoreProperties(ignoreUnknown = true)
-//@OwlIndividual(OwlClasses.OSF_WIKI)
 public class Wiki {
 
-    /*unique OSF ID for the file**/
-    //@Id
-    //@IndividualUri(transform = ProviderIdTransform.class)
     private String id;
 
-    /**list of comments associated with wiki*/
-    //@Relationship(value = "comments", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.OBJECT)
     private List<Comment> comments;
 
-    /**Gets other links found in data.links:{} section of JSON**/
-    //@Links
-    //@OwlProperty(value = OwlProperties.OSF_HAS_BINARYURI, transform = DownloadLinkTransform.class)
-    Map<String, ?> links;
+    private Map<String, ?> links;
 
-    /**name of the wiki; used for display*/
-    //@OwlProperty(OwlProperties.OSF_HAS_NAME)
     private String name;
 
-    /**"file" or "folder"*/
-    //@OwlProperty(OwlProperties.OSF_HAS_HASKIND)
     private String kind;
 
-    /**the unix-style path to the file relative to the provider root*/
-    //@OwlProperty(OwlProperties.OSF_HAS_MATERIALIZEDPATH)
     private String materialized_path;
 
-    /**timestamp of when this wiki was last updated*/
-    //@OwlProperty(value = OwlProperties.OSF_HAS_DATEMODIFIED, transform = DateTimeTransform.class)
     private DateTime date_modified;
 
-    /**node this wiki belongs to*/
-    //@OwlProperty(OwlProperties.OSF_HAS_NODE)
     private String node;
 
-    /**user that owns this wiki*/
-    //@OwlProperty(OwlProperties.OSF_HAS_NODE)
     private String user;
 
-    /**same as for corresponding WaterButler entity*/
-    //@OwlProperty(OwlProperties.OSF_HAS_PATH)
     private String path;
 
-    /**  */
-    //@OwlProperty(OwlProperties.OSF_HAS_PATH)
     private String content_type;
 
-    /**version of wiki*/
-    //@OwlProperty(OwlProperties.OSF_HAS_SIZE)
-    private Integer version;
+    private Map<String, ?> extra; // for "version"
 
-    /**size of wiki in bytes, null for folders*/
-    //@OwlProperty(OwlProperties.OSF_HAS_SIZE)
-    private Integer size;
+    private int size;
 
 
     public String getKind() {
@@ -181,21 +143,27 @@ public class Wiki {
         this.content_type = content_type;
     }
 
-    public Integer getSize() {
+    public int getSize() {
         return size;
     }
 
-    public void setSize(Integer size) {
+    public void setSize(int size) {
         this.size = size;
     }
 
-    public Integer getVersion() {
-        return version;
+    public Map<String, ?> getLinks() {
+        return links;
     }
 
-    public void setVersion(Integer version) {
-        this.version = version;
+    public void setLinks(Map<String, ?> links) {
+        this.links = links;
     }
+
+    public Map<String, ?> getVersion() {
+        return extra;
+    }
+
+    public void setVersion(Map<String, ?> extra) { this.extra = extra; }
 
     public String getId() {
         return id;

--- a/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/model/Wiki.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.cos.osf.client.model;
+
+import static org.dataconservancy.cos.osf.client.support.JodaSupport.DATE_TIME_FORMATTER_ALT;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import org.dataconservancy.cos.osf.client.support.DateTimeTransform;
+import org.dataconservancy.cos.osf.client.support.DownloadLinkTransform;
+import org.dataconservancy.cos.osf.client.support.FileIdTransform;
+import org.dataconservancy.cos.osf.client.support.JodaSupport;
+import org.dataconservancy.cos.osf.client.support.ProviderIdTransform;
+import org.dataconservancy.cos.rdf.annotations.IndividualUri;
+import org.dataconservancy.cos.rdf.annotations.OwlIndividual;
+import org.dataconservancy.cos.rdf.annotations.OwlProperty;
+import org.dataconservancy.cos.rdf.support.OwlClasses;
+import org.dataconservancy.cos.rdf.support.OwlProperties;
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.jasminb.jsonapi.RelType;
+import com.github.jasminb.jsonapi.ResolutionStrategy;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Links;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+
+
+/**
+ * Wiki model for OSF
+ * Created by Ben Trumbore on 9/16/2016.
+ */
+//@Type("wiki")
+//@JsonIgnoreProperties(ignoreUnknown = true)
+//@OwlIndividual(OwlClasses.OSF_WIKI)
+public class Wiki {
+
+    /*unique OSF ID for the file**/
+    //@Id
+    //@IndividualUri(transform = ProviderIdTransform.class)
+    private String id;
+
+    /**list of comments associated with wiki*/
+    //@Relationship(value = "comments", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.OBJECT)
+    private List<Comment> comments;
+
+    /**Gets other links found in data.links:{} section of JSON**/
+    //@Links
+    //@OwlProperty(value = OwlProperties.OSF_HAS_BINARYURI, transform = DownloadLinkTransform.class)
+    Map<String, ?> links;
+
+    /**name of the wiki; used for display*/
+    //@OwlProperty(OwlProperties.OSF_HAS_NAME)
+    private String name;
+
+    /**"file" or "folder"*/
+    //@OwlProperty(OwlProperties.OSF_HAS_HASKIND)
+    private String kind;
+
+    /**the unix-style path to the file relative to the provider root*/
+    //@OwlProperty(OwlProperties.OSF_HAS_MATERIALIZEDPATH)
+    private String materialized_path;
+
+    /**timestamp of when this wiki was last updated*/
+    //@OwlProperty(value = OwlProperties.OSF_HAS_DATEMODIFIED, transform = DateTimeTransform.class)
+    private DateTime date_modified;
+
+    /**node this wiki belongs to*/
+    //@OwlProperty(OwlProperties.OSF_HAS_NODE)
+    private String node;
+
+    /**user that owns this wiki*/
+    //@OwlProperty(OwlProperties.OSF_HAS_NODE)
+    private String user;
+
+    /**same as for corresponding WaterButler entity*/
+    //@OwlProperty(OwlProperties.OSF_HAS_PATH)
+    private String path;
+
+    /**  */
+    //@OwlProperty(OwlProperties.OSF_HAS_PATH)
+    private String content_type;
+
+    /**version of wiki*/
+    //@OwlProperty(OwlProperties.OSF_HAS_SIZE)
+    private Integer version;
+
+    /**size of wiki in bytes, null for folders*/
+    //@OwlProperty(OwlProperties.OSF_HAS_SIZE)
+    private Integer size;
+
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getNode() {
+        return node;
+    }
+
+    public void setNode(String node) {
+        this.node = node;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getMaterialized_path() {
+        return materialized_path;
+    }
+
+    public void setMaterialized_path(String materialized_path) {
+        this.materialized_path = materialized_path;
+    }
+
+    public String getDate_modified() {
+        if (this.date_modified!=null) {
+            return this.date_modified.toString(DATE_TIME_FORMATTER_ALT);
+        } else {
+            return null;
+        }
+    }
+
+    public void setDate_modified(String date_modified) {
+        if (date_modified!=null){
+            this.date_modified = JodaSupport.parseDateTime(date_modified);
+        } else {
+            date_modified=null;
+        }
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getContentType() {
+        return content_type;
+    }
+
+    public void setContentType(String content_type) {
+        this.content_type = content_type;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Comment> getComments() { return comments; }
+
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+
+}

--- a/src/main/java/org/dataconservancy/cos/osf/client/service/OsfService.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/service/OsfService.java
@@ -28,6 +28,7 @@ import org.dataconservancy.cos.osf.client.model.Node;
 import org.dataconservancy.cos.osf.client.model.Registration;
 import org.dataconservancy.cos.osf.client.model.RegistrationId;
 import org.dataconservancy.cos.osf.client.model.User;
+import org.dataconservancy.cos.osf.client.model.Wiki;
 
 import retrofit.Call;
 import retrofit.http.GET;
@@ -110,6 +111,7 @@ public interface OsfService {
 
     @GET
     Call<List<Contributor>> contributors(@Url String url);
-       
+
+
     //Call<List<NodeFile>> listFiles(@Path(""))
 }

--- a/src/main/java/org/dataconservancy/cos/osf/client/service/OsfService.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/service/OsfService.java
@@ -112,6 +112,8 @@ public interface OsfService {
     @GET
     Call<List<Contributor>> contributors(@Url String url);
 
+    @GET
+    Call<List<Wiki>> wikis(@Url String url);
 
     //Call<List<NodeFile>> listFiles(@Path(""))
 }

--- a/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
+++ b/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  * Copyright 2016 Johns Hopkins University
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.dataconservancy.cos.osf.client.model;
+
+import org.dataconservancy.cos.osf.client.service.OsfService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Ben Trumbore on 9/20/16.
+ */
+public class WikiTest extends AbstractMockServerTest {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private OsfService osfService;
+
+    @Before
+    public void setUp() throws Exception {
+        factory.interceptors().add(new RecursiveInterceptor(testName, WikiTest.class, getBaseUri()));
+        osfService = factory.getOsfService(OsfService.class);
+    }
+
+    @Test
+    public void testWikiMapping() throws Exception {
+        String wikiEndpoint = "http://localhost:8000/v2/registrations/ng9em/wikis/";
+        List<Wiki> wikis = osfService.wikis(wikiEndpoint).execute().body();
+
+        assertNotNull(wikis);
+        assertEquals(1, wikis.size());
+
+        Wiki pjnbm = wikis.stream()
+                .filter(c -> c.getId().equals("pjnbm"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Missing expected wiki pjnbm"));
+
+        assertTrue(pjnbm.getNode().endsWith("ng9em/"));
+        assertTrue(pjnbm.getUser().endsWith("3rty2/"));
+        // TODO - Can something be included for "comments"?
+
+        assertEquals(pjnbm.getKind(), "file");
+        assertEquals(pjnbm.getName(), "home");
+        //assertEquals(pjnbm.getDateModified(), "2016-09-13T22:24:10.128000");
+        //assertEquals(pjnbm.getContentType(), "text/markdown");
+        assertEquals(pjnbm.getPath(), "/pjnbm");
+        //assertEquals(pjnbm.getMaterializedPath(), "/pjnbm");
+        assertEquals(pjnbm.getSize(), 916);
+        assertEquals(pjnbm.getId(), "pjnbm");
+        // TODO - What to do about extra, which contains version?
+
+    }
+}

--- a/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
+++ b/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -59,17 +60,17 @@ public class WikiTest extends AbstractMockServerTest {
 
         assertTrue(pjnbm.getNode().endsWith("ng9em/"));
         assertTrue(pjnbm.getUser().endsWith("3rty2/"));
-        // TODO - Can something be included for "comments"?
+        // TODO - Check "comments" here.
 
-        assertEquals(pjnbm.getKind(), "file");
-        assertEquals(pjnbm.getName(), "home");
-        //assertEquals(pjnbm.getDateModified(), "2016-09-13T22:24:10.128000");
-        //assertEquals(pjnbm.getContentType(), "text/markdown");
-        assertEquals(pjnbm.getPath(), "/pjnbm");
-        //assertEquals(pjnbm.getMaterializedPath(), "/pjnbm");
-        assertEquals(pjnbm.getSize(), 916);
-        assertEquals(pjnbm.getId(), "pjnbm");
-        // TODO - What to do about extra, which contains version?
+        assertEquals("file", pjnbm.getKind());
+        assertEquals("home", pjnbm.getName());
+        assertEquals("2016-09-13T22:24:10.128Z", pjnbm.getDate_modified());
+        assertEquals("text/markdown", pjnbm.getContent_type());
+        assertEquals("/pjnbm", pjnbm.getPath());
+        assertEquals("/pjnbm", pjnbm.getMaterialized_path());
+        assertEquals(916, pjnbm.getSize());
+        assertEquals("pjnbm", pjnbm.getId());
+        assertEquals(1, pjnbm.getExtra().get("version"));
 
     }
 }

--- a/src/test/resources/json/WikiTest/testWikiMapping/nodes/ng9em/comments/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/nodes/ng9em/comments/index.json
@@ -1,0 +1,7 @@
+{
+    "errors": [
+        {
+            "detail": "Not found."
+        }
+    ]
+}

--- a/src/test/resources/json/WikiTest/testWikiMapping/registrations/ng9em/wikis/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/registrations/ng9em/wikis/index.json
@@ -1,0 +1,54 @@
+{
+    "data": [
+        {
+            "relationships": {
+                "node": {
+                    "links": {
+                        "related": {
+                            "href": "https://test-api.osf.io/v2/nodes/ng9em/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "links": {
+                        "related": {
+                            "href": "https://test-api.osf.io/v2/users/3rty2/",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "https://test-api.osf.io/v2/wikis/pjnbm/",
+                "download": "https://test-api.osf.io/v2/wikis/pjnbm/content/",
+                "self": "https://test-api.osf.io/v2/wikis/pjnbm/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "home",
+                "date_modified": "2016-09-13T22:24:10.128000",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/pjnbm",
+                "current_user_can_comment": true,
+                "materialized_path": "/pjnbm",
+                "size": 916
+            },
+            "type": "wikis",
+            "id": "pjnbm"
+        }
+    ],
+    "links": {
+        "first": null,
+        "last": null,
+        "prev": null,
+        "next": null,
+        "meta": {
+            "total": 1,
+            "per_page": 10
+        }
+    }
+}

--- a/src/test/resources/json/WikiTest/testWikiMapping/wikis/pjnbm/content/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/wikis/pjnbm/content/index.json
@@ -1,0 +1,14 @@
+<html>
+<head>
+</head>
+<body>
+<pre style="word-wrap: break-word; white-space: pre-wrap;">
+Here is some Wiki content.  It's pretty beautiful, I know.  You got **your bold**, *your italic*, and even [a link][1].  Wow.
+
+ - And of course, a bullet.
+ - That should be enough.
+
+  [1]: http://cac.cornell.edu
+</pre>
+</body>
+</html>

--- a/src/test/resources/json/WikiTest/testWikiMapping/wikis/pjnbm/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/wikis/pjnbm/index.json
@@ -1,0 +1,42 @@
+{
+    "data": {
+        "relationships": {
+            "node": {
+                "links": {
+                    "related": {
+                        "href": "https://test-api.osf.io/v2/nodes/ng9em/",
+                        "meta": {}
+                    }
+                }
+            },
+            "user": {
+                "links": {
+                    "related": {
+                        "href": "https://test-api.osf.io/v2/users/3rty2/",
+                        "meta": {}
+                    }
+                }
+            }
+        },
+        "links": {
+            "info": "https://test-api.osf.io/v2/wikis/pjnbm/",
+            "download": "https://test-api.osf.io/v2/wikis/pjnbm/content/",
+            "self": "https://test-api.osf.io/v2/wikis/pjnbm/"
+        },
+        "attributes": {
+            "kind": "file",
+            "name": "home",
+            "date_modified": "2016-09-13T22:24:10.128000",
+            "extra": {
+                "version": 1
+            },
+            "content_type": "text/markdown",
+            "path": "/pjnbm",
+            "current_user_can_comment": true,
+            "materialized_path": "/pjnbm",
+            "size": 916
+        },
+        "type": "wikis",
+        "id": "pjnbm"
+    }
+}


### PR DESCRIPTION
Elliot,

Here is an initial implementation for the Wiki class.  I used the File class as a model and copied code from there, adding missing elements as needed.  You don't have to accept this as a pull request, it's mainly so we can discuss my work and what comes next.  Here are some notes I made as I worked on the code.

• Looking at the File class, it seems like it is for both a folder and a file.
    o       Folder has relationships: files, node.  File has relationships: node, comments, versions.
• In File, Node is stored as an attribute - is that because there can be only one?  By that logic, I made User an attribute.
• I left out the pageLinks found in File, but wasn't sure what it did (it did not appear in the OSF JSON).
• File does not include some of its attributes: last_touched, current_user_can_comment, guid, checkout, tags.
    o       I left current_user_can_comment out of Wiki as well, but added content_type, which might not be needed.
• Much as "hashes" was found in File's "extra" section, I included "version" from Wiki's extra section.
• "type" was not included in File, so I left it out of Wiki.
• Is File's "links" for the top level links, or the one inside "data"?  Wiki only has the one inside "data".
• Import statements were just copied from File.  I will clean these up after annotations are complete.
• I kept the property ordering that was found in File.  Would it be OK to reorder them as they appear in Wiki OSF JSON?

Ben
