### PR TITLE
Cause wikis to be parsed when parsing registrations/nodes from OSF

### DIFF
--- a/src/main/java/org/dataconservancy/cos/osf/client/model/NodeBase.java
+++ b/src/main/java/org/dataconservancy/cos/osf/client/model/NodeBase.java
@@ -102,6 +102,7 @@ public abstract class NodeBase {
 	@OwlProperty(OwlProperties.OSF_HAS_LICENSE)
 	private License license;
 
+	@Relationship(value = "wikis", resolve = true, relType = RelType.RELATED, strategy = ResolutionStrategy.OBJECT)
 	@OwlProperty(OwlProperties.OSF_HAS_WIKI)
 	private List<Wiki> wikis;
 

--- a/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
+++ b/src/test/java/org/dataconservancy/cos/osf/client/model/WikiTest.java
@@ -47,9 +47,11 @@ public class WikiTest extends AbstractMockServerTest {
 
     @Test
     public void testWikiMapping() throws Exception {
-        String wikiEndpoint = "http://localhost:8000/v2/registrations/ng9em/wikis/";
-        List<Wiki> wikis = osfService.wikis(wikiEndpoint).execute().body();
+        String registrationId = "ng9em";
+        Registration registration = osfService.registration(registrationId).execute().body();
+        assertNotNull(registration);
 
+        List<Wiki> wikis = registration.getWikis();
         assertNotNull(wikis);
         assertEquals(1, wikis.size());
 

--- a/src/test/resources/json/CommentTest/testSimpleMapping/nodes/u9dc7/wikis/index.json
+++ b/src/test/resources/json/CommentTest/testSimpleMapping/nodes/u9dc7/wikis/index.json
@@ -1,0 +1,13 @@
+{
+  "data": [ ],
+  "links": {
+    "first": null,
+    "last": null,
+    "prev": null,
+    "next": null,
+    "meta": {
+      "total": 1,
+      "per_page": 10
+    }
+  }
+}

--- a/src/test/resources/json/EventTest/testEventMapping/nodes/eq7a4/comments/index.json
+++ b/src/test/resources/json/EventTest/testEventMapping/nodes/eq7a4/comments/index.json
@@ -1,0 +1,13 @@
+{
+  "data": [ ],
+  "links": {
+    "first": null,
+    "last": null,
+    "prev": null,
+    "next": null,
+    "meta": {
+      "total": 1,
+      "per_page": 10
+    }
+  }
+}

--- a/src/test/resources/json/WikiTest/testWikiMapping/registrations/sb4ec/comments/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/registrations/sb4ec/comments/index.json
@@ -1,0 +1,13 @@
+{
+    "data": [],
+    "links": {
+        "first": null,
+        "last": null,
+        "prev": null,
+        "next": null,
+        "meta": {
+            "total": 0,
+            "per_page": 10
+        }
+    }
+}

--- a/src/test/resources/json/WikiTest/testWikiMapping/registrations/sb4ec/wikis/index.json
+++ b/src/test/resources/json/WikiTest/testWikiMapping/registrations/sb4ec/wikis/index.json
@@ -1,0 +1,62 @@
+{
+    "data": [
+        {
+            "relationships": {
+                "node": {
+                    "links": {
+                        "related": {
+                            "href": "http://localhost:8000/v2/nodes/sb4ec/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "user": {
+                    "links": {
+                        "related": {
+                            "href": "http://localhost:8000/v2/users/3rty2/",
+                            "meta": {}
+                        }
+                    }
+                },
+                "comments": {
+                    "links": {
+                        "related": {
+                            "href": "http://localhost:8000/v2/registrations/sb4ec/comments/?filter=%5Btarget%5D=cz58v",
+                            "meta": {}
+                        }
+                    }
+                }
+            },
+            "links": {
+                "info": "http://localhost:8000/v2/wikis/cz58v/",
+                "download": "http://localhost:8000/v2/wikis/cz58v/content/",
+                "self": "http://localhost:8000/v2/wikis/cz58v/"
+            },
+            "attributes": {
+                "kind": "file",
+                "name": "home",
+                "date_modified": "2016-09-13T22:28:17.893000",
+                "extra": {
+                    "version": 1
+                },
+                "content_type": "text/markdown",
+                "path": "/cz58v",
+                "current_user_can_comment": true,
+                "materialized_path": "/cz58v",
+                "size": 184
+            },
+            "type": "wikis",
+            "id": "cz58v"
+        }
+    ],
+    "links": {
+        "first": null,
+        "last": null,
+        "prev": null,
+        "next": null,
+        "meta": {
+            "total": 1,
+            "per_page": 10
+        }
+    }
+}


### PR DESCRIPTION
Added a relationship for NodeBase wikis that will cause them to be
loaded.  Augment the wiki unit test to access the test wiki from a
registration, exercising the new relationship.  Added four data files
required to make unit tests pass.
